### PR TITLE
add configuration option to generate "dumb" URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,29 @@ sftp:
   host: secure.backup
 ```
 
+### use_public_url: Generate plain ("dumb") URLs of upload server
+
+By default the generated URLs will include parameters for `content_disposition`, expiration hints etc.  A generated blobs URL might thus look like:
+
+    https://publichost/PATH/rails/active_storage/disk/hash-hash/name.JPG?content_type=image%2Fjpeg&disposition=inline%3B+filename%3D
+
+If you prefer simple URLs like
+
+    https://publichost/PATH/hash
+
+you can set a configuration option:
+
+```yml
+# config/storage.yml
+sftp:
+  service: SFTP
+  user: user
+  root: /var/www/proj/shared/storage
+  host: file.intranet
+  public_host: https://file.internet
+  simple_public_urls: true
+```
+
 
 ## Contributing
 

--- a/lib/active_storage/service/sftp_service.rb
+++ b/lib/active_storage/service/sftp_service.rb
@@ -11,13 +11,14 @@ module ActiveStorage
 
     attr_reader :host, :user, :root, :public_host, :public_root
 
-    def initialize(host:, user:, public_host: nil, root: './', public_root: './', password: nil)
+    def initialize(host:, user:, public_host: nil, root: './', public_root: './', password: nil, simple_public_urls: false)
       @host = host
       @user = user
       @root = root
       @public_host = public_host
       @public_root = public_root
       @password = password
+      @simple_public_urls = simple_public_urls
     end
 
     def upload(key, io, checksum: nil, **)
@@ -133,38 +134,51 @@ module ActiveStorage
       end
     end
 
+    def url(key, expires_in:, filename:, disposition:, content_type:)
+      if @simple_public_urls
+        public_url(key)
+      else
+        classic_url(key,
+                    expires_in: expires_in,
+                    filename: filename,
+                    disposition: disposition,
+                    content_type: content_type)
+      end
+    end
+
+    def classic_url(key, expires_in:, filename:, disposition:, content_type:)
+      instrument :url, key: key do |payload|
+        raise NotConfigured, "public_host not defined." unless public_host
+        content_disposition = content_disposition_with(type: disposition, filename: filename)
+        verified_key_with_expiration = ActiveStorage.verifier.generate(
+          {
+            key: key,
+            disposition: content_disposition,
+            content_type: content_type
+          },
+          {
+            expires_in: expires_in,
+            purpose: :blob_key
+          }
+        )
+
+        generated_url = url_helpers.rails_disk_service_url(verified_key_with_expiration,
+                                                           host: public_host,
+                                                           disposition: content_disposition,
+                                                           content_type: content_type,
+                                                           filename: filename
+        )
+        payload[:url] = generated_url
+        generated_url
+      end
+    end
+
     def public_url(key)
       instrument :url, key: key do |payload|
         raise NotConfigured, "public_host not defined." unless public_host
         generated_url = File.join(public_host, public_root, path_for(key), key)
         payload[:url] = generated_url
         generated_url
-      end
-    end
-
-    def url(key, expires_in:, filename:, disposition:, content_type:)
-        instrument :url, key: key do |payload|
-          raise NotConfigured, "public_host not defined." unless public_host
-          content_disposition = content_disposition_with(type: disposition, filename: filename)
-          verified_key_with_expiration = ActiveStorage.verifier.generate(
-              {
-                  key: key,
-                  disposition: content_disposition,
-                  content_type: content_type
-              },
-              { expires_in: expires_in,
-                purpose: :blob_key }
-          )
-
-          generated_url = url_helpers.rails_disk_service_url(verified_key_with_expiration,
-                                                             host: public_host,
-                                                             disposition: content_disposition,
-                                                             content_type: content_type,
-                                                             filename: filename
-          )
-          payload[:url] = generated_url
-
-          generated_url
       end
     end
 


### PR DESCRIPTION
By default the generated URLs will include parameters for
`content_disposition`, expiration hints etc.  Add a configuration
option to circumvent that.