### PR TITLE
Fix duplicated key in public_url

### DIFF
--- a/lib/active_storage/service/sftp_service.rb
+++ b/lib/active_storage/service/sftp_service.rb
@@ -186,7 +186,7 @@ module ActiveStorage
     def public_url(key)
       instrument :url, key: key do |payload|
         raise NotConfigured, "public_host not defined." unless public_host
-        generated_url = File.join(public_host, public_root, path_for(key), key)
+        generated_url = File.join(public_host, public_root, path_for(key))
         payload[:url] = generated_url
         generated_url
       end


### PR DESCRIPTION
Hi,
this PR addresses an issue that I encountered while using the `simple_public_urls`.
I noticed that the url generated when calling `service_url` on the AS object returned an extra instance of the key in the path, like:
```
ftp://192.168.1.2:22/some_path/ab/cd/abcdiqsvd8fq2u8p6twq6rp4w7js/abcdiqsvd8fq2u8p6twq6rp4w7js
```
It looks like that the `key` property is appended twice when calling `public_url`. 
This Pr simply removes the extra key append. 

Hope this helps.
Thanks for your work on this adapter.