### PR TITLE
fix: use relative folder to generate public url

### DIFF
--- a/lib/active_storage/service/sftp_service.rb
+++ b/lib/active_storage/service/sftp_service.rb
@@ -186,7 +186,7 @@ module ActiveStorage
     def public_url(key)
       instrument :url, key: key do |payload|
         raise NotConfigured, "public_host not defined." unless public_host
-        generated_url = File.join(public_host, public_root, path_for(key))
+        generated_url = File.join(public_host, public_root, relative_folder_for(key), key)
         payload[:url] = generated_url
         generated_url
       end


### PR DESCRIPTION
On my app I needed to use `relative_folder_for` to generate the proper `public_url`. I'm not sure if everybody needs it or my app had some specificity.